### PR TITLE
Update to upstream riscv-arch-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,9 @@
 */__*
-
 riscof_work
-
 *.bin
 *.elf
 *.hex
 *.out
 *.signature
-
+*.log
 *.cf

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Currently, the following tests are supported:
 - [x] `rv32i_m\M` - hardware integer multiplication and division
 - [x] `rv32i_m\Zicond` - conditional operations
 - [x] `rv32i_m\Zifencei` - instruction stream synchronization
+- [x] `rv32i_m\hints` - hint instructions
+- [x] `rv32i_m\pmp` - physical memory protection (`M` + `U` modes)
 - [x] `rv32i_m\privilege` - privileged machine-mode architecture
 
 > [!TIP]

--- a/plugin-neorv32/env/link.ld
+++ b/plugin-neorv32/env/link.ld
@@ -3,7 +3,7 @@ ENTRY(rvtest_entry_point)
 
 SECTIONS
 {
-  . = 0x00000000;
+  . = 0x80000000;
   .text :
   {
     *(.text.init)

--- a/plugin-neorv32/neorv32_isa.yaml
+++ b/plugin-neorv32/neorv32_isa.yaml
@@ -14,18 +14,18 @@ hart0:
       mxl:
         implemented: true
         type:
-            warl:
-               dependency_fields: []
-               legal:
-                 - mxl[1:0] in [0x1]
-               wr_illegal:
-                 - unchanged
+          warl:
+            dependency_fields: []
+            legal:
+              - mxl[1:0] in [0x1]
+            wr_illegal:
+              - unchanged
       extensions:
         implemented: true
         type:
-            warl:
-               dependency_fields: []
-               legal:
-                 - extensions[25:0] in [0x0101105]
-               wr_illegal:
-                 - unchanged
+          warl:
+            dependency_fields: []
+            legal:
+              - extensions[25:0] in [0x0101105]
+            wr_illegal:
+              - unchanged

--- a/plugin-neorv32/neorv32_platform.yaml
+++ b/plugin-neorv32/neorv32_platform.yaml
@@ -1,10 +1,10 @@
 mtime:
   implemented: true
-  address: 0xFFFFFF90
+  address: 0xFFF4BFF8
 mtimecmp:
   implemented: true
-  address: 0xFFFFFF98
+  address: 0xFFF44000
 nmi:
   label: nmi_vector
 reset:
-  address: 0x00000000
+  address: 0x80000000

--- a/plugin-neorv32/riscof_neorv32.py
+++ b/plugin-neorv32/riscof_neorv32.py
@@ -183,6 +183,11 @@ class neorv32(pluginTemplate):
           logger.debug('DUT executing ' + execute)
           utils.shellCommand(execute).run()
 
+          # copy tracer log
+          execute = 'cp -f ./sim/neorv32.tracer0.log {0}/.'.format(test_dir)
+          logger.debug('DUT executing ' + execute)
+          utils.shellCommand(execute).run()
+
       # if target runs are not required then we simply exit as this point after running all
       # the makefile targets.
       if not self.target_run:

--- a/plugin-neorv32/riscof_neorv32.py
+++ b/plugin-neorv32/riscof_neorv32.py
@@ -96,20 +96,13 @@ class neorv32(pluginTemplate):
 
       # ---- NEORV32-specific ----
 
-      # Override default exception relocation list - remove EBREAK exception since NEORV32 clears MTVAL
-      # when encountering this type of exception (permitted by RISC-V priv. spec.)
-      print("<plugin-neorv32> overriding default SET_REL_TVAL_MSK macro (removing BREAKPOINT exception)")
+      # Override default exception relocation list (traps for MTVAL being set zero)
+      print("<plugin-neorv32> overriding default SET_REL_TVAL_MSK macro")
       neorv32_override  = ' \"-DSET_REL_TVAL_MSK=(('
-      neorv32_override += '(1<<CAUSE_MISALIGNED_FETCH) | '
-      neorv32_override += '(1<<CAUSE_FETCH_ACCESS)     | '
-#     neorv32_override += '(1<<CAUSE_BREAKPOINT)       | '
       neorv32_override += '(1<<CAUSE_MISALIGNED_LOAD)  | '
       neorv32_override += '(1<<CAUSE_LOAD_ACCESS)      | '
       neorv32_override += '(1<<CAUSE_MISALIGNED_STORE) | '
-      neorv32_override += '(1<<CAUSE_STORE_ACCESS)     | '
-      neorv32_override += '(1<<CAUSE_FETCH_PAGE_FAULT) | '
-      neorv32_override += '(1<<CAUSE_LOAD_PAGE_FAULT)  | '
-      neorv32_override += '(1<<CAUSE_STORE_PAGE_FAULT)   '
+      neorv32_override += '(1<<CAUSE_STORE_ACCESS)       '
       neorv32_override += ') & 0xFFFFFFFF)\" '
       self.compile_cmd += neorv32_override
 

--- a/plugin-sail_cSim/riscof_sail_cSim.py
+++ b/plugin-sail_cSim/riscof_sail_cSim.py
@@ -79,20 +79,13 @@ class sail_cSim(pluginTemplate):
             raise SystemExit(1)
 
         # ---- NEORV32-specific ----
-        # Override default exception relocation list - remove EBREAK exception since NEORV32 clears MTVAL
-        # when encountering this type of exception (permitted by RISC-V priv. spec.)
-        print("<plugin-sail_cSim> overriding default SET_REL_TVAL_MSK macro (removing BREAKPOINT exception)")
+        # Override default exception relocation list (traps for MTVAL being set zero)
+        print("<plugin-sail_cSim> overriding default SET_REL_TVAL_MSK macro")
         neorv32_override  = ' \"-DSET_REL_TVAL_MSK=(('
-        neorv32_override += '(1<<CAUSE_MISALIGNED_FETCH) | '
-        neorv32_override += '(1<<CAUSE_FETCH_ACCESS)     | '
-#       neorv32_override += '(1<<CAUSE_BREAKPOINT)       | '
         neorv32_override += '(1<<CAUSE_MISALIGNED_LOAD)  | '
         neorv32_override += '(1<<CAUSE_LOAD_ACCESS)      | '
         neorv32_override += '(1<<CAUSE_MISALIGNED_STORE) | '
-        neorv32_override += '(1<<CAUSE_STORE_ACCESS)     | '
-        neorv32_override += '(1<<CAUSE_FETCH_PAGE_FAULT) | '
-        neorv32_override += '(1<<CAUSE_LOAD_PAGE_FAULT)  | '
-        neorv32_override += '(1<<CAUSE_STORE_PAGE_FAULT)   '
+        neorv32_override += '(1<<CAUSE_STORE_ACCESS)       '
         neorv32_override += ') & 0xFFFFFFFF)\" '
         self.compile_cmd += neorv32_override
 

--- a/sim/neorv32_riscof_tb.vhd
+++ b/sim/neorv32_riscof_tb.vhd
@@ -27,8 +27,9 @@ end neorv32_riscof_tb;
 
 architecture neorv32_riscof_tb_rtl of neorv32_riscof_tb is
 
-  -- total memory size in bytes --
-  constant mem_size_c : natural := 4*1024*1024;
+  -- memory configuration --
+  constant mem_size_c : natural := 4*1024*1024; -- bytes
+  constant mem_base_c : std_ulogic_vector(31 downto 0) := x"80000000";
 
   -- memory type --
   type mem8_bv_t is array (natural range <>) of bit_vector(7 downto 0); -- bit_vector type for optimized system storage
@@ -96,8 +97,8 @@ begin
     -- Processor Clocking --
     CLOCK_FREQUENCY     => 100_000_000,
     -- Boot Configuration --
-    BOOT_MODE_SELECT  => 1, -- boot from BOOT_ADDR_CUSTOM
-    BOOT_ADDR_CUSTOM  => x"00000000",
+    BOOT_MODE_SELECT    => 1, -- boot from BOOT_ADDR_CUSTOM
+    BOOT_ADDR_CUSTOM    => mem_base_c,
     -- RISC-V CPU Extensions --
     RISCV_ISA_C         => true,
     RISCV_ISA_M         => true,
@@ -175,7 +176,7 @@ begin
       xmem_rdata <= (others => '0');
       xmem_ack   <= '0';
       -- bus access --
-      if (xbus.cyc = '1') and (xbus.stb = '1') and (xbus.addr(31 downto 28) = "0000") then
+      if (xbus.cyc = '1') and (xbus.stb = '1') and (xbus.addr(31 downto 28) = mem_base_c(31 downto 28)) then
         xmem_ack <= '1';
         if (xbus.we = '1') then
           if (xbus.sel(0) = '1') then mem8_bv_b0_v(mem_addr) := to_bitvector(xbus.wdata(07 downto 00)); end if;


### PR DESCRIPTION
* update to latest `riscv-arch-test` version (upstream `dev` branch)
* add support for `pmp` tests
* add support for `hints` tests